### PR TITLE
The setup is not based on a fixed endpoint any more. Removed usage of…

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -3,10 +3,12 @@
 const Foxx = require('org/arangodb/foxx');
 
 const queue = Foxx.queues.create('heartbeat');
-queue.all().forEach(jobId => queue.delete(jobId));
+queue.all().forEach(function (jobId) {
+  queue.delete(jobId);
+});
 const intervalInSeconds = applicationContext.configuration.interval;
 queue.push(
-  {mount: '/heartbeat', name: 'beat'},
+  {mount: applicationContext.mount, name: 'beat'},
   {interval: intervalInSeconds},
   {repeatTimes: -1, repeatDelay: intervalInSeconds * 1000}
 );


### PR DESCRIPTION
Hi,

i have removed the hard-coded mount point /heartbeat in the setup.js and replaced it with the automatic variable `applicationContext.mountpoint`.

i have replaced `(jobId) =>` with ES 5 style function. Can than be executed on any ArangoDB without additional harmony flags.

best
Michael
